### PR TITLE
fix(ci): run goreleaser on published event

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: Release App
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   goreleaser:


### PR DESCRIPTION
I pretty sure it didn't run after merging #1 due to it not being on `main` before.  The [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) indicate that `published` is the better trigger anyway.

If this fails again, i'm going to try `on.push.tags: ['*']`.

Fixes #9 