### PR TITLE
chore(ci): higher timeout so golangci can fill it's cache on first run w/o timeout

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Run GolangCI-Lint
         uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 3m
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This might fix the fact the the action is failing all the time (or that could just be a side effect of todays general instability)