### PR TITLE
refactor: decouple middlewares from server

### DIFF
--- a/app/middleware/authenticate.go
+++ b/app/middleware/authenticate.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/adfinis-sygroup/mopsos/app/types"
+)
+
+// Authenticate middleware handles checking credentials
+func Authenticate(next http.Handler, basicAuthUsers map[string]string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// get basic auth credentials
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			http.Error(w, "missing Authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"username": username,
+		}).Debug("checking credentials")
+		if basicAuthUsers[username] != password {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+			return
+		}
+		ctx := context.WithValue(r.Context(), types.ContextUsername, username)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/app/middleware/authenticate_test.go
+++ b/app/middleware/authenticate_test.go
@@ -1,0 +1,69 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/adfinis-sygroup/mopsos/app/middleware"
+	"github.com/adfinis-sygroup/mopsos/app/types"
+)
+
+func Test_Authenticate(t *testing.T) {
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Context().Value(types.ContextUsername) != "username" {
+			t.Error("username not set")
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.SetBasicAuth("username", "password")
+
+	res := httptest.NewRecorder()
+
+	auth := middleware.Authenticate(handler, map[string]string{"username": "password"})
+	auth.ServeHTTP(res, req)
+
+	if res.Result().StatusCode != http.StatusOK {
+		t.Errorf("status code should be 200")
+	}
+
+}
+
+func Test_AuthenticateNoHeader(t *testing.T) {
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+
+	res := httptest.NewRecorder()
+
+	auth := middleware.Authenticate(handler, map[string]string{"username": "password"})
+	auth.ServeHTTP(res, req)
+
+	if res.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("status code should be 401")
+	}
+}
+
+func Test_AuthenticateInvalidUser(t *testing.T) {
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.SetBasicAuth("username", "invalid")
+
+	res := httptest.NewRecorder()
+
+	auth := middleware.Authenticate(handler, map[string]string{"username": "password"})
+	auth.ServeHTTP(res, req)
+
+	if res.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("status code should be 401")
+	}
+}

--- a/app/middleware/load_event.go
+++ b/app/middleware/load_event.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	otelObs "github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client"
+	"github.com/cloudevents/sdk-go/v2/binding"
+	httproto "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/sirupsen/logrus"
+
+	"github.com/adfinis-sygroup/mopsos/app/types"
+)
+
+// LoadEvent middleware loads event from the request
+func LoadEvent(next http.Handler, enableTracing bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// get event
+		message := httproto.NewMessageFromHttpRequest(r)
+		event, err := binding.ToEvent(r.Context(), message)
+		if err != nil {
+			logrus.WithError(err).Error("failed to decode event")
+			return
+		}
+		if enableTracing {
+			// inject the span context into the event so it can be use i.e. while inserting to the database
+			otelObs.InjectDistributedTracingExtension(r.Context(), *event)
+		}
+		logrus.Debugf("received event: %v", event)
+
+		ctx := context.WithValue(r.Context(), types.ContextEvent, event)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/app/middleware/load_event_test.go
+++ b/app/middleware/load_event_test.go
@@ -1,0 +1,34 @@
+package middleware_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/adfinis-sygroup/mopsos/app/middleware"
+	"github.com/adfinis-sygroup/mopsos/app/types"
+)
+
+func Test_LoadEvent(t *testing.T) {
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		event := r.Context().Value(types.ContextEvent).(*cloudevents.Event)
+		if event.Type() != "test" {
+			t.Errorf("event type should be test")
+		}
+	})
+
+	body := []byte(`{"specversion":"1.0","type":"test"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhook", bytes.NewReader(body))
+	req.Header.Add("Content-Type", "application/cloudevents+json")
+
+	res := httptest.NewRecorder()
+
+	load := middleware.LoadEvent(handler, true)
+	load.ServeHTTP(res, req)
+
+	req.Body.Close()
+}

--- a/app/middleware/validate.go
+++ b/app/middleware/validate.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/sirupsen/logrus"
+
+	"github.com/adfinis-sygroup/mopsos/app/models"
+	"github.com/adfinis-sygroup/mopsos/app/types"
+)
+
+// Validate middleware handles checking received events for validity
+func Validate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		event := r.Context().Value(types.ContextEvent).(*event.Event)
+		record := &models.Record{}
+
+		if err := event.DataAs(record); err != nil {
+			logrus.WithError(err).Errorf("failed to unmarshal event data")
+			http.Error(w, "failed to unmarshal event data", http.StatusInternalServerError)
+			return
+		}
+
+		// reject record that have not been sent from the right auth
+		if record.ClusterName != r.Context().Value(types.ContextUsername).(string) {
+			http.Error(w, "event data does not match username", http.StatusUnauthorized)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), types.ContextRecord, record)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -1,12 +1,10 @@
 package app_test
 
 import (
-	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"gorm.io/gorm"
 
 	mopsos "github.com/adfinis-sygroup/mopsos/app"
@@ -38,90 +36,6 @@ func Test_ServerWithEventChannel(t *testing.T) {
 	if a.Server.EventChan != eventChan {
 		t.Errorf("event channel not set")
 	}
-}
-
-func Test_Authenticate(t *testing.T) {
-	a, _, _ := newApp()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Context().Value(mopsos.ContextUsername) != "username" {
-			t.Error("username not set")
-		}
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-	req.SetBasicAuth("username", "password")
-
-	res := httptest.NewRecorder()
-
-	auth := a.Server.Authenticate(handler)
-	auth.ServeHTTP(res, req)
-
-	if res.Result().StatusCode != http.StatusOK {
-		t.Errorf("status code should be 200")
-	}
-
-}
-
-func Test_AuthenticateNoHeader(t *testing.T) {
-	a, _, _ := newApp()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("handler should not be called")
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-
-	res := httptest.NewRecorder()
-
-	auth := a.Server.Authenticate(handler)
-	auth.ServeHTTP(res, req)
-
-	if res.Result().StatusCode != http.StatusUnauthorized {
-		t.Errorf("status code should be 401")
-	}
-}
-
-func Test_AuthenticateInvalidUser(t *testing.T) {
-	a, _, _ := newApp()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("handler should not be called")
-	})
-
-	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-	req.SetBasicAuth("username", "invalid")
-
-	res := httptest.NewRecorder()
-
-	auth := a.Server.Authenticate(handler)
-	auth.ServeHTTP(res, req)
-
-	if res.Result().StatusCode != http.StatusUnauthorized {
-		t.Errorf("status code should be 401")
-	}
-}
-
-func Test_LoadEvent(t *testing.T) {
-	a, _, _ := newApp()
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		event := r.Context().Value(mopsos.ContextEvent).(*cloudevents.Event)
-		if event.Type() != "test" {
-			t.Errorf("event type should be test")
-		}
-	})
-
-	body := []byte(`{"specversion":"1.0","type":"test"}`)
-	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhook", bytes.NewReader(body))
-	req.Header.Add("Content-Type", "application/cloudevents+json")
-
-	res := httptest.NewRecorder()
-
-	load := a.Server.LoadEvent(handler)
-	load.ServeHTTP(res, req)
-
-	req.Body.Close()
 }
 
 func Test_HandleHealthCheck(t *testing.T) {

--- a/app/types/eventContext.go
+++ b/app/types/eventContext.go
@@ -1,0 +1,7 @@
+package types
+
+type eventContext string
+
+var ContextUsername eventContext = "mopsos.username"
+var ContextEvent eventContext = "mopsos.event"
+var ContextRecord eventContext = "mopsos.record"


### PR DESCRIPTION
middleware funcs are not part of the Server (`s`) anymore and get their config injected via method injection instead of relying on `s.Config`.

This makes them easier to test in isolation and reduces the respoinsabilities of the Server class.