### PR TITLE
chore: remove unused distros

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,10 +9,7 @@ builds:
   - CGO_ENABLED=0
 archives:
 - replacements:
-    darwin: Darwin
     linux: Linux
-    windows: Windows
-    386: i386
     amd64: x86_64
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
This removes any build target that we don't currently aim at supporting and makes CI faster by doing so.

Please do reach out if you would like us to re-add any of these targets.